### PR TITLE
added index to url field

### DIFF
--- a/fstat/model.py
+++ b/fstat/model.py
@@ -20,7 +20,7 @@ class Failure(db.Model):
 
 class FailureInstance(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    url = db.Column(db.String(100))
+    url = db.Column(db.String(100), index=True)
     state = db.Column(db.Integer)
     job_name = db.Column(db.String(100), index=True)
     node = db.Column(db.String(100), index=True)


### PR DESCRIPTION
In parser you are using URL to search for failure instance so I think we should have index there also since without index the search will get slow and eventually the cron will have performance issues when the data grows.