### PR TITLE
Remove the db_init command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -12,11 +12,6 @@ manager.add_command('runserver', Server())
 manager.add_command('db', MigrateCommand)
 
 
-@manager.command
-def db_init():
-    db.create_all()
-
-
 @manager.option('-n', dest='num_days')
 @manager.option('-j', '--job', dest='job_name')
 def process_jobs(job_name, num_days):

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@
 from flask_script import Server, Manager
 from flask_migrate import MigrateCommand
 
-from fstat import app, db
+from fstat import app
 from fstat.parser import get_summary
 
 


### PR DESCRIPTION
This is not needed anymore. Alembic takes care of this. All one needs to
do during setup is `./manage.py db upgrade`.